### PR TITLE
Calcular total_paid/return_paid por fila mostrada en listado de ventas

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -387,6 +387,27 @@ class SellController extends Controller
                 }
             }
 
+            //total_paid y return_paid se calculan solo para las filas mostradas
+            //(no como subconsultas correlacionadas en la consulta base) usando el
+            //indice transaction_payments.transaction_id. Se cachea en la fila.
+            $get_total_paid = function ($row) {
+                if (! isset($row->total_paid)) {
+                    $row->total_paid = (float) \App\TransactionPayment::where('transaction_id', $row->id)
+                        ->sum(DB::raw('IF(is_return = 1, -1 * amount, amount)'));
+                }
+
+                return $row->total_paid;
+            };
+            $get_return_paid = function ($row) {
+                if (! isset($row->return_paid)) {
+                    $row->return_paid = empty($row->return_transaction_id)
+                        ? 0
+                        : (float) \App\TransactionPayment::where('transaction_id', $row->return_transaction_id)->sum('amount');
+                }
+
+                return $row->return_paid;
+            };
+
             $datatable = Datatables::of($sells);
             if (! is_null($total_count)) {
                 //Evita el count(*) envolvente pesado en la carga normal (sin busqueda).
@@ -520,7 +541,11 @@ class SellController extends Controller
                 )
                 ->editColumn(
                     'total_paid',
-                    '<span class="total-paid" data-orig-value="{{$total_paid}}">@format_currency($total_paid)</span>'
+                    function ($row) use ($get_total_paid) {
+                        $total_paid = $get_total_paid($row);
+
+                        return '<span class="total-paid" data-orig-value="'.$total_paid.'">'.$this->transactionUtil->num_f($total_paid, true).'</span>';
+                    }
                 )
                 ->editColumn(
                     'total_before_tax',
@@ -551,16 +576,16 @@ class SellController extends Controller
                     'types_of_service_name',
                     '<span class="service-type-label" data-orig-value="{{$types_of_service_name}}" data-status-name="{{$types_of_service_name}}">{{$types_of_service_name}}</span>'
                 )
-                ->addColumn('total_remaining', function ($row) {
-                    $total_remaining = $row->final_total - $row->total_paid;
+                ->addColumn('total_remaining', function ($row) use ($get_total_paid) {
+                    $total_remaining = $row->final_total - $get_total_paid($row);
                     $total_remaining_html = '<span class="payment_due" data-orig-value="'.$total_remaining.'">'.$this->transactionUtil->num_f($total_remaining, true).'</span>';
 
                     return $total_remaining_html;
                 })
-                ->addColumn('return_due', function ($row) {
+                ->addColumn('return_due', function ($row) use ($get_return_paid) {
                     $return_due_html = '';
                     if (! empty($row->return_exists)) {
-                        $return_due = $row->amount_return - $row->return_paid;
+                        $return_due = $row->amount_return - $get_return_paid($row);
                         $return_due_html .= '<a href="'.action([\App\Http\Controllers\TransactionPaymentController::class, 'show'], [$row->return_transaction_id]).'" class="view_purchase_return_payment_modal"><span class="sell_return_due" data-orig-value="'.$return_due.'">'.$this->transactionUtil->num_f($return_due, true).'</span></a>';
                     }
 

--- a/app/Utils/TransactionUtil.php
+++ b/app/Utils/TransactionUtil.php
@@ -5497,12 +5497,11 @@ class TransactionUtil extends Util
                     'transactions.custom_field_4',
                     DB::raw('DATE_FORMAT(transactions.transaction_date, "%Y/%m/%d") as sale_date'),
                     DB::raw("CONCAT(COALESCE(u.surname, ''),' ',COALESCE(u.first_name, ''),' ',COALESCE(u.last_name,'')) as added_by"),
-                    DB::raw('(SELECT SUM(IF(TP.is_return = 1,-1*TP.amount,TP.amount)) FROM transaction_payments AS TP WHERE
-                        TP.transaction_id=transactions.id) as total_paid'),
+                    //total_paid y return_paid se calculan por fila mostrada en el
+                    //controlador (no como subconsultas correlacionadas aqui) para
+                    //evitar evaluarlas sobre todo el conjunto y causar timeouts.
                     'bl.name as business_location',
                     DB::raw('COUNT(SR.id) as return_exists'),
-                    DB::raw('(SELECT SUM(TP2.amount) FROM transaction_payments AS TP2 WHERE
-                        TP2.transaction_id=SR.id ) as return_paid'),
                     DB::raw('COALESCE(SR.final_total, 0) as amount_return'),
                     'SR.id as return_transaction_id',
                     'tos.name as types_of_service_name',

--- a/resources/views/sell/index.blade.php
+++ b/resources/views/sell/index.blade.php
@@ -238,12 +238,13 @@
                     },
                     {
                         data: 'total_paid',
-                        name: 'total_paid',
+                        orderable: false,
                         "searchable": false
                     },
                     {
                         data: 'total_remaining',
-                        name: 'total_remaining'
+                        orderable: false,
+                        "searchable": false
                     },
                     {
                         data: 'return_due',


### PR DESCRIPTION
Las subconsultas correlacionadas (total_paid, return_paid) sobre transaction_payments se evaluaban para TODAS las filas del conjunto filtrado, tanto en el conteo como en la consulta de datos, causando lentitud/timeout.

Ahora:
- getListSells ya no incluye esas subconsultas correlacionadas.
- SellController@index las calcula solo para las (25) filas mostradas, via consultas indexadas por transaction_payments.transaction_id, cacheadas en la fila (closures get_total_paid / get_return_paid).
- Columnas total_paid y total_remaining marcadas no-ordenables (ya no son expresiones de BD; evita ORDER BY sobre alias inexistente).

Validado en local (MariaDB, base real business 32):
- Valores total_paid identicos al metodo anterior (25/25, 0 diferencias).
- 30 dias: conteo 136ms + datos 305ms (antes: timeout en el count).
- Full year/todas las bodegas: conteo 1358ms + datos 1944ms (antes >3s y timeout).